### PR TITLE
Remove bad characters in WPPv2 eps

### DIFF
--- a/03-01-04-04-eps.adoc
+++ b/03-01-04-04-eps.adoc
@@ -17,7 +17,7 @@ NOTE: Visit one of the integration guides
 a step-by-step guide before continuing.
 
 All <<PPv2, {payment-page-v2-abbr}>> integrations share a
-<<PPSolutions_PPv2_Workflow, common process flow>>﻿ for creating payments.
+<<PPSolutions_PPv2_Workflow, common process flow>> for creating payments.
 
 Below, you find example requests for the available transaction type
 <<PPv2_eps_TransactionType_debit, _debit_>>, 
@@ -32,11 +32,11 @@ contact <<ContactUs, merchant support>>.
 All given requests return successful responses.
 
 For more details on the ``redirect-url``, see the 
-<<PPSolutions_PPv2_ConfigureRedirects, Configuring Redirects and IPNs for {payment-page-v2-abbr}>>﻿﻿ 
+<<PPSolutions_PPv2_ConfigureRedirects, Configuring Redirects and IPNs for {payment-page-v2-abbr}>> 
 section.
 
 For response verification examples, see
-the <<PPSolutions_PPv2_PPv2Security, {payment-page-v2-abbr} Security>>﻿ section.
+the <<PPSolutions_PPv2_PPv2Security, {payment-page-v2-abbr} Security>> section.
 
 [#PPv2_eps_About]
 ====== About _eps_
@@ -91,8 +91,7 @@ the Austrian ones.
 [#PPv2_eps_TestCredentials]
 ====== Test Credentials
 
-Test Credentials for Transaction Type
-<<PPv2_eps_TransactionType_debit, _debit_>>.
+Test Credentials for Transaction Type <<PPv2_eps_TransactionType_debit, _debit_>>.
 
 .Merchant Credentials
 [cols="35,65"]
@@ -283,7 +282,7 @@ payments are returned as _failed_, but the
 In any case (unless the consumer cancels the transaction on a 3rd party
 provider page), a base64 encoded response containing payment information
 is sent to the configured redirection URL. See
-<<PPSolutions_PPv2_ConfigureRedirects, Configuring Redirects and IPNs for {payment-page-v2-abbr}>>﻿﻿
+<<PPSolutions_PPv2_ConfigureRedirects, Configuring Redirects and IPNs for {payment-page-v2-abbr}>> 
 for more details on redirection targets after payment & transaction status
 notifications.
 


### PR DESCRIPTION
Removed only 5 bad characters. 
No text modified. Can be merged immediately